### PR TITLE
Add relative path to run.sh command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pipenv sync
 
 4. Run the server
 ```
-pipenv run run.sh CONTROL_PLANE|PRIMARY_WORKER|EXPLORATORY_WORKER
+pipenv run ./run.sh CONTROL_PLANE|PRIMARY_WORKER|EXPLORATORY_WORKER
 ```
 
 


### PR DESCRIPTION
Without indicating the relative path, the following error would be thrown when executing the `pipenv run run.sh CONTROL_PLANE|PRIMARY_WORKER|EXPLORATORY_WORKER` command:

```
Virtualenv location:
Warning: There was an unexpected error while activating your virtualenv. Continuing anyway…
Error: the command run.sh could not be found within PATH or Pipfile's [scripts].
```